### PR TITLE
Make callout border colour work in hero area

### DIFF
--- a/source/stylesheets/modules/_hero.scss
+++ b/source/stylesheets/modules/_hero.scss
@@ -130,4 +130,9 @@
       @include grid-column(1 / 3);
     }
   }
+
+  .panel-border-wide {
+    border-color: $light-blue-25;
+  }
+
 }


### PR DESCRIPTION
The normal GOV.UK elements callout style is meant to be used on a white background. The grey border colour is a [tint](https://en.wikipedia.org/wiki/Tints_and_shades) of the normal text colour. The grey border colour looks jarring on the blue background.

When used with white text on a coloured background the border colour should be a tint of the text colour. In other words, a mixture of the text colour and the background colour.

GOV.UK Frontend Toolkit provides tints with the `-25` and `-50` suffixes on most colour variables. For some reason there is no `$govuk-blue-25` or `$govuk-blue-50`. But `$light-blue-25` looks right to my eyes, and matches the light blue used in the hero illustration, and the link hover
colour in the hero area (defined here: https://github.com/alphagov/verify-product-page/blob/25ffaf788744017b46339a23a6166acc1524f88c/source/stylesheets/modules/_hero.scss#L60)

# Before

<img width="1026" alt="screen shot 2017-01-23 at 15 48 38" src="https://cloud.githubusercontent.com/assets/355079/22210993/89deafe0-e183-11e6-92fe-30e4cd3aac11.png">

# After

<img width="1030" alt="screen shot 2017-01-23 at 15 48 22" src="https://cloud.githubusercontent.com/assets/355079/22211001/8f397fb0-e183-11e6-8168-34921477a9f6.png">
