### PR TITLE
BAU: Pinning govuk_elements to v3.0.1 in bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,6 +15,6 @@
   "dependencies": {
     "govuk_template": "https://github.com/alphagov/govuk_template.git#^0.19.2",
     "govuk_frontend_toolkit": "https://github.com/alphagov/govuk_frontend_toolkit.git#v5.0.2",
-    "govuk_elements": "https://github.com/alphagov/govuk_elements.git"
+    "govuk_elements": "https://github.com/alphagov/govuk_elements.git#3.0.1"
   }
 }


### PR DESCRIPTION
- Pinning govuk_elements to use v3.0.1 rather than latest which otherwise breaks the product page

Pair: @smford, @sonofbytes & @ajlanghorn