### PR TITLE
Update index.html.erb

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -60,7 +60,7 @@ title: Verify Product Page
       <section class="content-section content-section--with-top-border">
         <h2 class="content-section__title">Integrate GOV.UK Verify into your service</h2>
         <p class="content-section__body">To integrate GOV.UK Verify into your service, there’s an <a href="http://alphagov.github.io/identity-assurance-documentation/">onboarding process</a>.</p>
-        <p class="content-section__body">GOV.UK Verify is replacing Government Gateway. If you run a service that needs individuals to prove their identity, you must integrate GOV.UK Verify into your service by March 2018. If your users are businesses or agents, continue using Government Gateway.</p>
+        <p class="content-section__body">GOV.UK Verify is replacing Government Gateway soon. If you run a service that needs individuals to prove their identity, you must integrate GOV.UK Verify into your service. If your users are businesses or agents, continue using Government Gateway.</p>
       </section>
 
     </div>
@@ -95,7 +95,7 @@ title: Verify Product Page
     <div class="grid-row">
         <div class="column-one-quarter">
           <p>
-            <span class="data-item bold-xlarge">5</span>
+            <span class="data-item bold-xlarge">7</span>
             <span class="data-item bold-xsmall">
               departments
             </span>
@@ -103,7 +103,7 @@ title: Verify Product Page
         </div>
         <div class="column-one-quarter">
           <p>
-            <span class="data-item bold-xlarge">12</span>
+            <span class="data-item bold-xlarge">15</span>
             <span class="data-item bold-xsmall">
               services
             </span>
@@ -111,7 +111,7 @@ title: Verify Product Page
         </div>
         <div class="column-half">
           <p>
-            <span class="data-item bold-xlarge">Over 1 million</span>
+            <span class="data-item bold-xlarge">Over 1.8 million</span>
             <span class="data-item bold-xsmall">
               <a href="https://www.gov.uk/performance/govuk-verify/account-use">verified accounts</a>
             </span>


### PR DESCRIPTION
Updated:
- number of services using Verify (to 15) (final number came from engagement spreadsheet, including DBS check and digital licensing service)
- number of departments using Verify (to 7)
- number of users using Verify (to 1.8m)
- content saying Verify is replacing Government Gateway in March 2018.