### PR TITLE
Add Google Analytics tag

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -1,6 +1,15 @@
 <!doctype html>
 <html lang="en" class="no-js">
 <head>
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-26179049-27"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'UA-26179049-27');
+  </script>
   <meta charset="utf-8">
   <title><%= current_page.data.title && "#{current_page.data.title} – " %>GOV.UK Verify</title
   <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
Added Google Analytics global tracking tag to the `<head>` section of `layouts.erb` to track all pages on the product website.