### PR TITLE
BAU: Fix PaaS app name

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,6 @@
 ---
 applications:
-- name: govuk-verify
+- name: verify-product-page
   memory: 64M
   path: ./build
   buildpack: staticfile_buildpack


### PR DESCRIPTION
The app should be getting uploaded as `verify-product-page` instead of
`govuk-verify` since the `www.verify.service...` routes point to the former.