### PR TITLE
BAU: Add redirect to new product domain

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,4 @@
+*
+!build
+!Staticfile
+!nginx

--- a/Staticfile
+++ b/Staticfile
@@ -1,0 +1,2 @@
+root: build
+location_include: custom.conf

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,7 +1,8 @@
 ---
 applications:
-- name: govuk-verify
-  memory: 64M
-  path: ./build
-  buildpack: staticfile_buildpack
+- name: verify-product-page
+  memory: 256M
+  path: .
+  buildpacks:
+    - staticfile_buildpack
   instances: 2

--- a/nginx/conf/custom.conf
+++ b/nginx/conf/custom.conf
@@ -1,0 +1,5 @@
+add_header Cache-Control "max-age:60";
+
+if ($host != "www.verify.service.gov.uk") {
+  return 301 https://www.verify.service.gov.uk$request_uri;
+}


### PR DESCRIPTION
- We want the www.verify.service.gov.uk to be the source of truth so
  redirect if anyone tries to use an old link
- Uses a Staticfile and custom nginx configuration
- Add a .cfignore to avoid pushing all sorts of other stuff
  unnecessarily