### PR TITLE
BAU: Fix relative links

### DIFF
--- a/nginx/conf/custom.conf
+++ b/nginx/conf/custom.conf
@@ -1,4 +1,4 @@
-add_header Cache-Control "max-age:60";
+add_header Cache-Control "no-cache";
 
 if ($host != "www.verify.service.gov.uk") {
   return 301 https://www.verify.service.gov.uk$request_uri;

--- a/source/connecting.html.erb
+++ b/source/connecting.html.erb
@@ -28,21 +28,21 @@ title: Connecting to GOV.UK Verify
             <span class="task-list-section-number">1.</span>Check if you need GOV.UK Verify
           </h2>
           <p>
-            Before you start connecting your service to GOV.UK Verify, find out <a href="how-verify-works">how GOV.UK Verify works</a> and <a href="verify-right-for-your-service">if it’s right for your service</a>.
+            Before you start connecting your service to GOV.UK Verify, find out <a href="/how-verify-works">how GOV.UK Verify works</a> and <a href="/verify-right-for-your-service">if it’s right for your service</a>.
           </p>
 
           <h2 class="heading-medium">
             <span class="task-list-section-number">2.</span> Choose the right level of assurance
           </h2>
           <p>
-            GOV.UK Verify offers different <a href="understand-levels-of-assurance">levels of assurance</a> (LOAs). To help choose the right LOA for your service, <a href="risk-assessment">do a risk assessment</a> and send it to the GOV.UK Verify team. The team will contact you within a week to discuss the right LOA for your service.
+            GOV.UK Verify offers different <a href="/understand-levels-of-assurance">levels of assurance</a> (LOAs). To help choose the right LOA for your service, <a href="/risk-assessment">do a risk assessment</a> and send it to the GOV.UK Verify team. The team will contact you within a week to discuss the right LOA for your service.
           </p>
 
           <h2 class="heading-medium">
             <span class="task-list-section-number">3.</span> Design and research your user journey with GOV.UK Verify
           </h2>
           <p>
-            Find out <a href="design-your-service">how to fit GOV.UK Verify into your service’s user journey</a>, and <a href="do-research-prototype">do user research</a> to test how easily your users can complete the whole journey.
+            Find out <a href="/design-your-service">how to fit GOV.UK Verify into your service’s user journey</a>, and <a href="/do-research-prototype">do user research</a> to test how easily your users can complete the whole journey.
           </p>
 
           <h2 class="heading-medium">

--- a/source/design-your-service.html.erb
+++ b/source/design-your-service.html.erb
@@ -11,7 +11,7 @@ title: Design how your service sends users to GOV.UK Verify
       <a href="/" itemprop="item"><span itemprop="name">GOV.UK Verify</span></a>
     </li>
     <li class="breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-      <a href="connecting" itemprop="item"><span itemprop="name">Connecting to GOV.UK Verify</span></a>
+      <a href="/connecting" itemprop="item"><span itemprop="name">Connecting to GOV.UK Verify</span></a>
     </li>
     <li class="breadcrumbs__item breadcrumbs__item--active" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
       <a href="#main" itemprop="item"><span itemprop="name">Design how your service sends users to GOV.UK Verify</span></a>
@@ -34,10 +34,10 @@ title: Design how your service sends users to GOV.UK Verify
         </p>
         <ul class="list list-bullet">
           <li>
-            <a href="user-journey-loa1">LOA 1 service</a>
+            <a href="/user-journey-loa1">LOA 1 service</a>
           </li>
           <li>
-            <a href="user-journey-loa2">LOA 2 service</a>
+            <a href="/user-journey-loa2">LOA 2 service</a>
             </li>
         </ul>
         <h2 class="heading-large">
@@ -134,7 +134,7 @@ title: Design how your service sends users to GOV.UK Verify
           <img class="content-section__image image-border" src="/images/pattern-cant-be-verified.png" alt="Screenshot of what users see when they cannot be verified">
         </p>
         <p class="space-mt-30">
-          <a href="connecting">Return to overview</a>
+          <a href="/connecting">Return to overview</a>
         </p>
       </div>
     </div>

--- a/source/do-research-prototype.html.erb
+++ b/source/do-research-prototype.html.erb
@@ -11,7 +11,7 @@ title: Do research on your service using a GOV.UK Verify prototype
       <a href="/" itemprop="item"><span itemprop="name">GOV.UK Verify</span></a>
     </li>
     <li class="breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-      <a href="connecting" itemprop="item"><span itemprop="name">Connecting to GOV.UK Verify</span></a>
+      <a href="/connecting" itemprop="item"><span itemprop="name">Connecting to GOV.UK Verify</span></a>
     </li>
     <li class="breadcrumbs__item breadcrumbs__item--active" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
       <a href="#main" itemprop="item"><span itemprop="name">Do research on your service using a GOV.UK Verify prototype</span></a>
@@ -43,7 +43,7 @@ title: Do research on your service using a GOV.UK Verify prototype
           <li>Password: verifypass</li>
         </ul>
         <p class="space-mt-30">
-          <a href="connecting">Return to overview</a>
+          <a href="/connecting">Return to overview</a>
         </p>
       </div>
     </div>

--- a/source/how-verify-works.html.erb
+++ b/source/how-verify-works.html.erb
@@ -11,7 +11,7 @@ title: How GOV.UK Verify works
       <a href="/" itemprop="item"><span itemprop="name">GOV.UK Verify</span></a>
     </li>
     <li class="breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-      <a href="connecting" itemprop="item"><span itemprop="name">Connecting to GOV.UK Verify</span></a>
+      <a href="/connecting" itemprop="item"><span itemprop="name">Connecting to GOV.UK Verify</span></a>
     </li>
     <li class="breadcrumbs__item breadcrumbs__item--active" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
       <a href="#main" itemprop="item"><span itemprop="name">How GOV.UK Verify works</span></a>
@@ -74,7 +74,7 @@ title: How GOV.UK Verify works
           </li>
         </ul>
         <p class="space-mt-30">
-          <a href="connecting">Return to overview</a>
+          <a href="/connecting">Return to overview</a>
         </p>
       </div>
     </div>

--- a/source/risk-assessment.html.erb
+++ b/source/risk-assessment.html.erb
@@ -11,7 +11,7 @@ title: Assess the risk of identity fraud to your service
       <a href="/" itemprop="item"><span itemprop="name">GOV.UK Verify</span></a>
     </li>
     <li class="breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-      <a href="connecting" itemprop="item"><span itemprop="name">Connecting to GOV.UK Verify</span></a>
+      <a href="/connecting" itemprop="item"><span itemprop="name">Connecting to GOV.UK Verify</span></a>
     </li>
     <li class="breadcrumbs__item breadcrumbs__item--active" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
       <a href="#main" itemprop="item"><span itemprop="name">Assess the risk of identity fraud to your service</span></a>
@@ -27,7 +27,7 @@ title: Assess the risk of identity fraud to your service
           Assess the risk of identity fraud to your service
         </h1>
         <p>
-          Before you choose the right <a href="understand-levels-of-assurance">level of assurance</a> (LOA) for your service, you should do a risk assessment and discuss the results with the GOV.UK Verify team. This will help you understand what makes your service more or less likely to be targeted by online identity fraud. Think about why your service needs identity assurance and the risks you are trying to protect against.
+          Before you choose the right <a href="/understand-levels-of-assurance">level of assurance</a> (LOA) for your service, you should do a risk assessment and discuss the results with the GOV.UK Verify team. This will help you understand what makes your service more or less likely to be targeted by online identity fraud. Think about why your service needs identity assurance and the risks you are trying to protect against.
         </p>
         <p>
           You should focus on the risks associated with someone using a false identity or another person’s identity to access your service. This is different from eligibility, which is about whether users have the right to use your service (for example, users are only eligible to <a href="https://www.gov.uk/apply-universal-credit">apply for Universal Credit</a> if they have less than £16,000 in savings).
@@ -64,7 +64,7 @@ title: Assess the risk of identity fraud to your service
           </li>
         </ul>
         <p class="space-mt-30">
-          <a href="connecting">Return to overview</a>
+          <a href="/connecting">Return to overview</a>
         </p>
       </div>
     </div>

--- a/source/understand-levels-of-assurance.html.erb
+++ b/source/understand-levels-of-assurance.html.erb
@@ -11,7 +11,7 @@ title: Understand the different levels of assurance
       <a href="/" itemprop="item"><span itemprop="name">GOV.UK Verify</span></a>
     </li>
     <li class="breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-      <a href="connecting" itemprop="item"><span itemprop="name">Connecting to GOV.UK Verify</span></a>
+      <a href="/connecting" itemprop="item"><span itemprop="name">Connecting to GOV.UK Verify</span></a>
     </li>
     <li class="breadcrumbs__item breadcrumbs__item--active" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
       <a href="#main" itemprop="item"><span itemprop="name">Understand the different levels of assurance</span></a>
@@ -30,7 +30,7 @@ title: Understand the different levels of assurance
           GOV.UK Verify is designed to protect services and users from online identity fraud. It provides 2 different levels of assurance (LOAs) - LOA 1 and LOA 2. The higher the LOA, the more confident you can be that your users are who they say they are.
         </p>
         <p>
-          When you understand the different LOAs, you should do a <a href="risk-assessment">risk assessment</a> and discuss the results with the GOV.UK Verify team - they will help you choose the right LOA for your service
+          When you understand the different LOAs, you should do a <a href="/risk-assessment">risk assessment</a> and discuss the results with the GOV.UK Verify team - they will help you choose the right LOA for your service
         </p>
         <p>
           LOA 1 is the lowest level of assurance offered by GOV.UK Verify. It is usually appropriate if you assess that your service’s risk of identity fraud is low.
@@ -162,7 +162,7 @@ title: Understand the different levels of assurance
           Email <a href="mailto:idasupport@digital.cabinet-office.gov.uk">idasupport@digital.cabinet-office.gov.uk</a> if you need help choosing the right level of assurance for your service.
         </p>
         <p class="space-mt-30">
-          <a href="connecting">Return to overview</a>
+          <a href="/connecting">Return to overview</a>
         </p>
       </div>
     </div>

--- a/source/user-journey-loa1.html.erb
+++ b/source/user-journey-loa1.html.erb
@@ -11,10 +11,10 @@ title: How the LOA 1 user journey works
       <a href="/" itemprop="item"><span itemprop="name">GOV.UK Verify</span></a>
     </li>
     <li class="breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-      <a href="connecting" itemprop="item"><span itemprop="name">Connecting to GOV.UK Verify</span></a>
+      <a href="/connecting" itemprop="item"><span itemprop="name">Connecting to GOV.UK Verify</span></a>
     </li>
     <li class="breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-      <a href="connecting" itemprop="item"><span itemprop="name">Design how your service sends users to GOV.UK Verify</span></a>
+      <a href="/connecting" itemprop="item"><span itemprop="name">Design how your service sends users to GOV.UK Verify</span></a>
     </li>
     <li class="breadcrumbs__item breadcrumbs__item--active" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
       <a href="#main" itemprop="item"><span itemprop="name">How the LOA 1 user journey works</span></a>
@@ -30,7 +30,7 @@ title: How the LOA 1 user journey works
           How the LOA 1 user journey works
         </h1>
         <p>
-          This is a typical user journey for a level of assurance (LOA) 1 service. It’s different to the <a href="user-journey-loa2">user journey for an LOA 2 service</a>.
+          This is a typical user journey for a level of assurance (LOA) 1 service. It’s different to the <a href="/user-journey-loa2">user journey for an LOA 2 service</a>.
         </p>
         <p>
           It typically takes about 5 minutes to create a GOV.UK Verify account, and less than a minute to sign in after that point.
@@ -149,7 +149,7 @@ title: How the LOA 1 user journey works
         </ol>
 
         <div class="space-mt-30">
-          <a href="design-your-service">Return to Design how your service sends users to GOV.UK Verify</a>
+          <a href="/design-your-service">Return to Design how your service sends users to GOV.UK Verify</a>
         </div>
 
       </div>

--- a/source/user-journey-loa2.html.erb
+++ b/source/user-journey-loa2.html.erb
@@ -11,10 +11,10 @@ title: How the LOA 2 user journey works
       <a href="/" itemprop="item"><span itemprop="name">GOV.UK Verify</span></a>
     </li>
     <li class="breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-      <a href="connecting" itemprop="item"><span itemprop="name">Connecting to GOV.UK Verify</span></a>
+      <a href="/connecting" itemprop="item"><span itemprop="name">Connecting to GOV.UK Verify</span></a>
     </li>
     <li class="breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-      <a href="connecting" itemprop="item"><span itemprop="name">Design how your service sends users to GOV.UK Verify</span></a>
+      <a href="/connecting" itemprop="item"><span itemprop="name">Design how your service sends users to GOV.UK Verify</span></a>
     </li>
     <li class="breadcrumbs__item breadcrumbs__item--active" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
       <a href="#main" itemprop="item"><span itemprop="name">How the LOA 2 user journey works</span></a>
@@ -30,7 +30,7 @@ title: How the LOA 2 user journey works
           How the LOA 2 user journey works
         </h1>
         <p>
-          This is a typical user journey for a level of assurance (LOA) 2 service. It’s different to the <a href="user-journey-loa1">user journey for an LOA 1 service</a>.
+          This is a typical user journey for a level of assurance (LOA) 2 service. It’s different to the <a href="/user-journey-loa1">user journey for an LOA 1 service</a>.
         </p>
         <p>
           Before they sign up to GOV.UK Verify, users will be asked some questions to help them choose the right certified company.
@@ -190,7 +190,7 @@ title: How the LOA 2 user journey works
         </ol>
 
         <div class="space-mt-30">
-          <a href="design-your-service">Return to Design how your service sends users to GOV.UK Verify</a>
+          <a href="/design-your-service">Return to Design how your service sends users to GOV.UK Verify</a>
         </div>
 
       </div>

--- a/source/verify-right-for-your-service.html.erb
+++ b/source/verify-right-for-your-service.html.erb
@@ -11,7 +11,7 @@ title: Find out if GOV.UK Verify is right for your service
       <a href="/" itemprop="item"><span itemprop="name">GOV.UK Verify</span></a>
     </li>
     <li class="breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-      <a href="connecting" itemprop="item"><span itemprop="name">Connecting to GOV.UK Verify</span></a>
+      <a href="/connecting" itemprop="item"><span itemprop="name">Connecting to GOV.UK Verify</span></a>
     </li>
     <li class="breadcrumbs__item breadcrumbs__item--active" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
       <a href="#main" itemprop="item"><span itemprop="name">Find out if GOV.UK Verify is right for your service</span></a>
@@ -101,7 +101,7 @@ title: Find out if GOV.UK Verify is right for your service
           Email <a href="mailto:idasupport@digital.cabinet-office.gov.uk">idasupport@digital.cabinet-office.gov.uk</a> if you need help deciding whether GOV.UK Verify is right for your service.
         </p>
         <p class="space-mt-30">
-          <a href="connecting">Return to overview</a>
+          <a href="/connecting">Return to overview</a>
         </p>
       </div>
     </div>


### PR DESCRIPTION
- When running locally with middleman all these links resolved properly
  but when deployed they are resolving as relative links
- Adding an explicit forward slash at the beginning tells the browser
  they are absolute
- Also, fix the caching header as it was wrongly formatted and we
  probably don't need a cache at all given expected traffic