### PR TITLE
Fixed Staticfile causing failed deploy to PaaS

### DIFF
--- a/Staticfile
+++ b/Staticfile
@@ -1,2 +1,2 @@
-root: source
+root: build
 location_include: custom.conf


### PR DESCRIPTION
When pushing to PaaS you need to run the buildscript which puts everything in a build directory.
Therefore meaning the staticfile was looking for source which doesnt exist.
Changed the root to build instead of source.