### PR TITLE
[After March 1st] Remove Royal Mail and Citizensafe

### DIFF
--- a/source/how-verify-works.html.erb
+++ b/source/how-verify-works.html.erb
@@ -33,7 +33,7 @@ title: How GOV.UK Verify works
           The identity providers have met government and industry standards to provide identity assurance services as part of GOV.UK Verify. They work with GOV.UK Verify to ensure users’ data is handled securely, helping your service to meet its data protection obligations.
         </p>
         <p>
-          The identity providers that currently work with GOV.UK Verify are Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail and SecureIdentity.
+          The identity providers that currently work with GOV.UK Verify are Barclays, Digidentity, Experian, Post Office and SecureIdentity.
         </p>
         <h2 class="heading-large">
           How users are verified during the signup journey


### PR DESCRIPTION
As of 1st March, they will no longer be acting as identity providers for Verify.

See https://trello.com/c/vi7RV11M