### PR TITLE
Add Home Office logo to product page

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -172,34 +172,45 @@ title: GOV.UK Verify
           <p>
             GOV.UK Verify has been designed and tested by GDS and it’s being used across government. More than 3 million users are using GOV.UK Verify to access <a href="https://www.gov.uk/government/publications/introducing-govuk-verify/introducing-govuk-verify#government-services">services</a> run by organisations including:
           </p>
-            <div class="column-half org__margin">
+          <div class="grid-row org-row">
+            <div class="column-third org__margin">
               <div class="org-logo brand--department-for-environment-food-rural-affairs">
                 <div class="org-logo__container org-logo__crest org-logo__crest--single-identity brand__border-color">
                   <span class="org-logo__name">Department<br>for Environment<br>Food &amp; Rural Affairs</span>
                 </div>
               </div>
             </div>
-            <div class="column-half org__margin">
+            <div class="column-third org__margin">
               <div class="org-logo brand--department-for-work-pensions">
                 <div class="org-logo__container org-logo__crest org-logo__crest--single-identity brand__border-color">
                   <span class="org-logo__name">Department<br>for Work &amp;<br>Pensions</span>
                 </div>
               </div>
             </div>
-            <div class="column-half org__margin">
+            <div class="column-third org__margin">
               <div class="org-logo brand--department-for-transport">
                 <div class="org-logo__container org-logo__crest org-logo__crest--single-identity brand__border-color">
                   <span class="org-logo__name">Driver &amp; Vehicle<br>Licensing<br>Agency</span>
                 </div>
               </div>
             </div>
-            <div class="column-half org__margin">
+          </div>
+          <div class="grid-row org-row">
+            <div class="column-third org__margin">
               <div class="org-logo brand--hm-revenue-customs">
                 <div class="org-logo__container org-logo__crest org-logo__crest--hmrc brand__border-color">
                   <span class="org-logo__name">HM Revenue<br>&amp; Customs</span>
                 </div>
               </div>
             </div>
+            <div class="column-third org__margin">
+              <div class="org-logo brand--home-office">
+                <div class="org-logo__container org-logo__crest org-logo__crest--ho brand__border-color">
+                  <span class="org-logo__name">Home Office</span>
+                </div>
+              </div>
+            </div>
+          </div>
             <div class="panel panel-border-wide">
               <p>
                 “Being able to verify their identity online saves our users time and means we can start processing their application quicker.”

--- a/source/stylesheets/modules/_org-logos.scss
+++ b/source/stylesheets/modules/_org-logos.scss
@@ -1,5 +1,9 @@
 // department logos (adapted from GOV.UK organisation pages)
 
+.grid-row.org-row {
+  margin: 0;
+}
+
 .org__margin {
   margin: 0 0 30px -15px;
 }
@@ -42,6 +46,11 @@
   background-size: auto 20px;
 }
 
+.org-logo__crest--ho {
+  background: url("https://assets.publishing.service.gov.uk/collections/crests/ho_crest_18px_x2-37e8a7b20e2d79993b80bb4e7c1965f4f50eaec9737e2333f7ad88a042aa2ed5.png") no-repeat 5px 0;
+  background-size: auto 20px;
+}
+
 .brand--department-for-environment-food-rural-affairs .brand__border-color {
   border-color: #00a33b;
 }
@@ -56,6 +65,10 @@
 
 .brand--hm-revenue-customs .brand__border-color {
     border-color: #009390;
+}
+
+.brand--home-office .brand__border-color {
+    border-color: #9325b2;
 }
 
 @media (min-width: 641px) {
@@ -77,6 +90,11 @@
 
   .org-logo__crest--hmrc {
     background: url("https://assets.publishing.service.gov.uk/government/assets/crests/hmrc_crest_27px_x2-50c5ae1eac742b467695f5889f93024627e14f1c03a39db7a8e55edfe5d4417a.png") no-repeat 6px 0;
+    background-size: auto 26px;
+  }
+
+  .org-logo__crest--ho {
+    background: url("https://assets.publishing.service.gov.uk/collections/crests/ho_crest_18px_x2-37e8a7b20e2d79993b80bb4e7c1965f4f50eaec9737e2333f7ad88a042aa2ed5.png") no-repeat 6px 0;
     background-size: auto 26px;
   }
 


### PR DESCRIPTION
Small change to add the Home Office logo to the product page.

Also took the chance to slightly modify the grid structure around the logos to stop weird wrapping on smaller screens.