### PR TITLE
Update privacy bullets

### DIFF
--- a/source/how-verify-works.html.erb
+++ b/source/how-verify-works.html.erb
@@ -52,9 +52,6 @@ title: How GOV.UK Verify works
           <li>
             your service does not know which identity provider they’ve chosen
           </li>
-          <li>
-            the identity provider does not know the user is trying to use your service
-          </li>
         </ol>
         <p>
           <img class="content-section__image image-border" src="/images/how-verify-works-simple.svg" alt="Diagram explaining how GOV.UK Verify works">


### PR DESCRIPTION
Update privacy bullets to remove claim that "the identity provider does not know the user is trying to use your service" - this is no longer true in the Single IDP route.