### PR TITLE
Try using `bundle exec middleman build` instead of `build.sh`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 cache: bundler
-script: ./build.sh
+script: bundle exec middleman build
 deploy:
   provider: cloudfoundry
   api: https://api.cloud.service.gov.uk


### PR DESCRIPTION
I'm not convinced all the stuff inside `build.sh` is needed. Trying with just the middleman build command to see if the automated Travis build breaks.