### PR TITLE
BAU: Upgrade PaaS stack to cflinuxfs3

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -6,3 +6,4 @@ applications:
   buildpacks:
     - staticfile_buildpack
   instances: 2
+  stack: cflinuxfs3


### PR DESCRIPTION
Canonical are withdrawing support for Trusty and, as such, the
cflinuxfs2 stack that is based on Trusty is being withdrawn at the end
of April.