### PR TITLE
Removing LOA space

### DIFF
--- a/source/design-your-service.html.erb
+++ b/source/design-your-service.html.erb
@@ -34,10 +34,10 @@ title: Design how your service sends users to GOV.UK Verify
         </p>
         <ul class="list list-bullet">
           <li>
-            <a href="/user-journey-loa1">LOA 1 service</a>
+            <a href="/user-journey-loa1">LOA1 service</a>
           </li>
           <li>
-            <a href="/user-journey-loa2">LOA 2 service</a>
+            <a href="/user-journey-loa2">LOA2 service</a>
             </li>
         </ul>
         <h2 class="heading-large">

--- a/source/understand-levels-of-assurance.html.erb
+++ b/source/understand-levels-of-assurance.html.erb
@@ -134,7 +134,7 @@ title: Understand the different levels of assurance
           </p>
         </div>
         <h3 class="heading-medium">
-          LOA and your users
+          LOA2 and your users
         </h3>
         <p>
           If your service uses LOA2, it will take users:

--- a/source/understand-levels-of-assurance.html.erb
+++ b/source/understand-levels-of-assurance.html.erb
@@ -27,36 +27,36 @@ title: Understand the different levels of assurance
           Understand the different levels of assurance
         </h1>
         <p>
-          GOV.UK Verify is designed to protect services and users from online identity fraud. It provides 2 different levels of assurance (LOAs) - LOA 1 and LOA 2. The higher the LOA, the more confident you can be that your users are who they say they are.
+          GOV.UK Verify is designed to protect services and users from online identity fraud. It provides 2 different levels of assurance (LOAs) - LOA1 and LOA2. The higher the LOA, the more confident you can be that your users are who they say they are.
         </p>
         <p>
           When you understand the different LOAs, you should do a <a href="/risk-assessment">risk assessment</a> and discuss the results with the GOV.UK Verify team - they will help you choose the right LOA for your service
         </p>
         <p>
-          LOA 1 is the lowest level of assurance offered by GOV.UK Verify. It is usually appropriate if you assess that your service’s risk of identity fraud is low.
+          LOA1 is the lowest level of assurance offered by GOV.UK Verify. It is usually appropriate if you assess that your service’s risk of identity fraud is low.
         </p>
         <p>
-          If your assessment indicates your service faces a high risk of identity fraud (for instance, because it offers something of high value such as money or a licence), you might want to use LOA 2.
+          If your assessment indicates your service faces a high risk of identity fraud (for instance, because it offers something of high value such as money or a licence), you might want to use LOA2.
         </p>
         <p>
           If you think your users face a high risk of harm if your service is affected by online identity fraud, email <a href="mailto:idasupport@digital.cabinet-office.gov.uk">idasupport@digital.cabinet-office.gov.uk</a> to discuss:
         </p>
         <ul class="list list-bullet">
           <li>
-            LOA 3 &ndash; appropriate when a user could face serious consequences from someone else using their identity, such as physical harm or financial ruin
+            LOA3 &ndash; appropriate when a user could face serious consequences from someone else using their identity, such as physical harm or financial ruin
           </li>
           <li>
-            LOA 4 &ndash; appropriate when a user’s life could be threatened by someone else using their identity
+            LOA4 &ndash; appropriate when a user’s life could be threatened by someone else using their identity
           </li>
         </ul>
         <h2 class="heading-large">
-          LOA 1
+          LOA1
         </h2>
         <p>
-          LOA 1 checks the user’s identity against one or more pieces of identity evidence. This often includes asking questions that only the person the user is claiming to be would know the answer to.
+          LOA1 checks the user’s identity against one or more pieces of identity evidence. This often includes asking questions that only the person the user is claiming to be would know the answer to.
         </p>
         <p>
-          LOA 1 is suitable for most services that:
+          LOA1 is suitable for most services that:
         </p>
         <ul class="list list-bullet">
           <li>
@@ -71,17 +71,17 @@ title: Understand the different levels of assurance
             Example
           </h3>
           <p>
-            The Driver and Vehicle Licensing Agency (DVLA) uses LOA 1 in their <a href="https://www.gov.uk/view-driving-licence">view driving licence information</a> service. This is because the service lets users see information that is not sensitive, and faces a low risk of identity fraud.
+            The Driver and Vehicle Licensing Agency (DVLA) uses LOA1 in their <a href="https://www.gov.uk/view-driving-licence">view driving licence information</a> service. This is because the service lets users see information that is not sensitive, and faces a low risk of identity fraud.
           </p>
           <p>
             If a user impersonated someone else to use this service, it is unlikely they would be able to use this information to do any harm to that person.
           </p>
         </div>
         <h3 class="heading-medium">
-          LOA 1 and your users
+          LOA1 and your users
         </h3>
         <p>
-          If your service uses LOA 1, it will take users:
+          If your service uses LOA1, it will take users:
         </p>
         <ul class="list list-bullet">
           <li>
@@ -106,13 +106,13 @@ title: Understand the different levels of assurance
           </li>
         </ul>
         <h2 class="heading-large">
-          LOA 2
+          LOA2
         </h2>
         <p>
-          LOA 2 offers a higher level of confidence about your users’ identities. It uses multiple pieces of identity evidence, as well as the user’s financial or other history, to check their identity.
+          LOA2 offers a higher level of confidence about your users’ identities. It uses multiple pieces of identity evidence, as well as the user’s financial or other history, to check their identity.
         </p>
         <p>
-          LOA 2 might be suitable for your service if it:
+          LOA2 might be suitable for your service if it:
         </p>
         <ul class="list list-bullet">
           <li>
@@ -127,17 +127,17 @@ title: Understand the different levels of assurance
             Example
           </h3>
           <p>
-            The Department for Business, Energy and Industrial Strategy (BEIS) uses LOA 2 in their <a href="https://www.gov.uk/claim-redundancy">claim for redundancy and monies owed</a> service. This is because it could face a high risk of identity fraud.
+            The Department for Business, Energy and Industrial Strategy (BEIS) uses LOA2 in their <a href="https://www.gov.uk/claim-redundancy">claim for redundancy and monies owed</a> service. This is because it could face a high risk of identity fraud.
           </p>
           <p>
             If a user impersonated someone else to use this service, they could get money they’re not entitled to. This could also stop the real user from being paid money they’re owed.
           </p>
         </div>
         <h3 class="heading-medium">
-          LOA 2 and your users
+          LOA and your users
         </h3>
         <p>
-          If your service uses LOA 2, it will take users:
+          If your service uses LOA2, it will take users:
         </p>
         <ul class="list list-bullet">
           <li>

--- a/source/user-journey-loa1.html.erb
+++ b/source/user-journey-loa1.html.erb
@@ -1,5 +1,5 @@
 ---
-title: How the LOA 1 user journey works
+title: How the LOA1 user journey works
 ---
 
 <nav class="breadcrumbs" aria-label="Breadcrumbs">
@@ -17,7 +17,7 @@ title: How the LOA 1 user journey works
       <a href="/connecting" itemprop="item"><span itemprop="name">Design how your service sends users to GOV.UK Verify</span></a>
     </li>
     <li class="breadcrumbs__item breadcrumbs__item--active" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-      <a href="#main" itemprop="item"><span itemprop="name">How the LOA 1 user journey works</span></a>
+      <a href="#main" itemprop="item"><span itemprop="name">How the LOA1 user journey works</span></a>
     </li>
   </ol>
 </nav>
@@ -27,10 +27,10 @@ title: How the LOA 1 user journey works
     <div class="grid-row">
       <div class="column-two-thirds">
         <h1 class="heading-xlarge">
-          How the LOA 1 user journey works
+          How the LOA1 user journey works
         </h1>
         <p>
-          This is a typical user journey for a level of assurance (LOA) 1 service. It’s different to the <a href="/user-journey-loa2">user journey for an LOA 2 service</a>.
+          This is a typical user journey for a level of assurance 1 (LOA1) service. It’s different to the <a href="/user-journey-loa2">user journey for an LOA2 service</a>.
         </p>
         <p>
           It typically takes about 5 minutes to create a GOV.UK Verify account, and less than a minute to sign in after that point.

--- a/source/user-journey-loa2.html.erb
+++ b/source/user-journey-loa2.html.erb
@@ -1,5 +1,5 @@
 ---
-title: How the LOA 2 user journey works
+title: How the LOA2 user journey works
 ---
 
 <nav class="breadcrumbs" aria-label="Breadcrumbs">
@@ -17,7 +17,7 @@ title: How the LOA 2 user journey works
       <a href="/connecting" itemprop="item"><span itemprop="name">Design how your service sends users to GOV.UK Verify</span></a>
     </li>
     <li class="breadcrumbs__item breadcrumbs__item--active" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-      <a href="#main" itemprop="item"><span itemprop="name">How the LOA 2 user journey works</span></a>
+      <a href="#main" itemprop="item"><span itemprop="name">How the LOA2 user journey works</span></a>
     </li>
   </ol>
 </nav>
@@ -27,10 +27,10 @@ title: How the LOA 2 user journey works
     <div class="grid-row">
       <div class="column-two-thirds">
         <h1 class="heading-xlarge">
-          How the LOA 2 user journey works
+          How the LOA2 user journey works
         </h1>
         <p>
-          This is a typical user journey for a level of assurance (LOA) 2 service. It’s different to the <a href="/user-journey-loa1">user journey for an LOA 1 service</a>.
+          This is a typical user journey for a level of assurance 2 (LOA2) service. It’s different to the <a href="/user-journey-loa1">user journey for an LOA1 service</a>.
         </p>
         <p>
           Before they sign up to GOV.UK Verify, users will be asked some questions to help them choose the right certified company.


### PR DESCRIPTION
As per the agreed changes to the style guide, I removed the space between "LOA" and the number. 

See the Trello card: https://trello.com/c/sa4NXMNy/476-update-instances-of-loa-1-2-to-loa1-2 
See updated style guide: https://govukverify.atlassian.net/wiki/spaces/COREVERIFY/pages/624918535/Verify+style+guide 