### PR TITLE
BAU: Update GOV.UK Frontend to 3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,14 +5,14 @@
   "requires": true,
   "dependencies": {
     "gaap-analytics": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/gaap-analytics/-/gaap-analytics-3.0.0.tgz",
-      "integrity": "sha1-kZJTXE+3Z4SCcqVZoBjfGr18wVA="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/gaap-analytics/-/gaap-analytics-3.1.0.tgz",
+      "integrity": "sha512-9G7Hwy/D2bjFymOQIptNArrTDAgGjssAv+L6SvbAJinDOSzeX9zUc46PnDVA5WPHHUC5+er4y9+o/nYbubwPoA=="
     },
     "govuk-frontend": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.0.0.tgz",
-      "integrity": "sha512-GCrEeaQZEnsthNtfmOUFlgsieNjHOeoamSWMdD4Gdq0RPxCA9uzfrT2i3jVnlBORekKjOL0C8eFZQBSNnjtz2A=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.1.0.tgz",
+      "integrity": "sha512-ozyG6ulmawzg3rsf9Efxcgj81mk4yzea3tfl0hgmXWILGC0/uEGj6A+g9pJ2ETgk78rgNlRLXDv0WvlaHd/LnA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/alphagov/verify-product-page#readme",
   "dependencies": {
-    "gaap-analytics": "^3.0.0",
-    "govuk-frontend": "^3.0.0"
+    "gaap-analytics": "^3.1.0",
+    "govuk-frontend": "^3.1.0"
   }
 }


### PR DESCRIPTION
Some accessibility fixes between 3.0 and 3.1 were introduced.

And update to GaaP Analytics package.