### PR TITLE
Let's be WCAG 2.1 compliant

### DIFF
--- a/source/connecting.html.erb
+++ b/source/connecting.html.erb
@@ -2,7 +2,7 @@
 title: Connecting to GOV.UK Verify
 ---
 <div class="govuk-width-container">
-  <div class="govuk-breadcrumbs">
+  <nav aria-label="Breadcrumb" class="govuk-breadcrumbs">
     <ol class="govuk-breadcrumbs__list">
       <li class="govuk-breadcrumbs__list-item">
         <a class="govuk-breadcrumbs__link" href="https://www.gov.uk/service-toolkit#components">Components</a>
@@ -14,7 +14,7 @@ title: Connecting to GOV.UK Verify
         <a href="#main">Connecting to GOV.UK Verify</a>
       </li>
     </ol>
-  </div>
+  </nav>
 </div>
 
 <main class="govuk-main-wrapper" id="main" role="main">

--- a/source/design-your-service.html.erb
+++ b/source/design-your-service.html.erb
@@ -3,7 +3,7 @@ title: Design how your service sends users to GOV.UK Verify
 ---
 
 <div class="govuk-width-container">
-  <div class="govuk-breadcrumbs">
+  <nav aria-label="Breadcrumb" class="govuk-breadcrumbs">
     <ol class="govuk-breadcrumbs__list">
       <li class="govuk-breadcrumbs__list-item">
         <a class="govuk-breadcrumbs__link" href="https://www.gov.uk/service-toolkit#components">Components</a>
@@ -18,7 +18,7 @@ title: Design how your service sends users to GOV.UK Verify
         <a href="#main">Design how your service sends users to GOV.UK Verify</a>
       </li>
     </ol>
-  </div>
+  </nav>
 </div>
 
 <main class="govuk-main-wrapper" id="main" role="main">

--- a/source/do-research-prototype.html.erb
+++ b/source/do-research-prototype.html.erb
@@ -3,7 +3,7 @@ title: Do research on your service using a GOV.UK Verify prototype
 ---
 
 <div class="govuk-width-container">
-  <div class="govuk-breadcrumbs">
+  <nav aria-label="Breadcrumb" class="govuk-breadcrumbs">
     <ol class="govuk-breadcrumbs__list">
       <li class="govuk-breadcrumbs__list-item">
         <a class="govuk-breadcrumbs__link" href="https://www.gov.uk/service-toolkit#components">Components</a>
@@ -18,7 +18,7 @@ title: Do research on your service using a GOV.UK Verify prototype
         <a href="#main">Do research on your service using a GOV.UK Verify prototype</a>
       </li>
     </ol>
-  </div>
+  </nav>
 </div>
 
 <main class="govuk-main-wrapper" id="main" role="main">

--- a/source/how-verify-works.html.erb
+++ b/source/how-verify-works.html.erb
@@ -3,7 +3,7 @@ title: How GOV.UK Verify works
 ---
 
 <div class="govuk-width-container">
-  <div class="govuk-breadcrumbs">
+  <nav aria-label="Breadcrumb" class="govuk-breadcrumbs">
     <ol class="govuk-breadcrumbs__list">
       <li class="govuk-breadcrumbs__list-item">
         <a class="govuk-breadcrumbs__link" href="https://www.gov.uk/service-toolkit#components">Components</a>
@@ -18,7 +18,7 @@ title: How GOV.UK Verify works
         <a href="#main">How GOV.UK Verify works</a>
       </li>
     </ol>
-  </div>
+  </nav>
 </div>
 
 <main class="govuk-main-wrapper" id="main" role="main">

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -35,7 +35,7 @@ title: GOV.UK Verify
         </div>
         <div class="govuk-grid-column-one-third">
           <div class="hero__aside-image">
-            <img src="images/verify-product-image.svg" alt="Illustration of GOV.UK Verify passing secure data between a user and a government service" role="presentation">
+            <img src="images/verify-product-image.svg" alt="" role="presentation">
           </div>
         </div>
       </div>

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -179,7 +179,7 @@ title: GOV.UK Verify
             You do not need to build your own digital identity check from scratch or go through a long procurement process.
           </p>
           <p class="govuk-body">
-            GOV.UK Verify has been designed and tested by GDS and it’s being used across government. More than 3 million users are using GOV.UK Verify to access <a href="https://www.gov.uk/government/publications/introducing-govuk-verify/introducing-govuk-verify#government-services">services</a> run by organisations including:
+            GOV.UK Verify has been designed and tested by GDS and it’s being used across government. More than 3 million users are using GOV.UK Verify to access <a href="https://www.gov.uk/government/publications/introducing-govuk-verify/introducing-govuk-verify#government-services" class="govuk-link">services</a> run by organisations including:
           </p>
           <div class="govuk-grid-row org-row">
             <div class="govuk-grid-column-one-third org__margin">

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -2,9 +2,9 @@
 title: GOV.UK Verify
 ---
 
-<div class="masthead">
+<div class="masthead masthead--breadcrumb">
   <div class="govuk-width-container">
-    <div class="govuk-breadcrumbs govuk-breadcrumbs--inverse">
+    <nav aria-label="Breadcrumb" class="govuk-breadcrumbs govuk-breadcrumbs--inverse">
       <ol class="govuk-breadcrumbs__list">
         <li class="govuk-breadcrumbs__list-item">
           <a class="govuk-breadcrumbs__link" href="https://www.gov.uk/service-toolkit#components">Components</a>
@@ -13,37 +13,41 @@ title: GOV.UK Verify
           <a href="#main">GOV.UK Verify</a>
         </li>
       </ol>
-    </div>
+    </nav>
+  </div>
+</div>
 
-    <div class="hero">
-      <div class="hero__content govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <div class="hero__body">
-            <h1 class="hero__title govuk-heading-xl">
-              Be sure your users are who they say they are
-            </h1>
-            <p class="hero__description govuk-body">
-              GOV.UK Verify is a trusted, secure way to prove identity online. Designed to prevent identity fraud and protect users’ privacy, it’s a safe way to make sure you’re giving the right people access to your service.
-            </p>
-            <a href="/connecting" role="button" draggable="false" class="hero-button govuk-button govuk-button--start" data-module="govuk-button" data-click-events data-click-category="Hero" data-click-action="Button clicked">
-              Find out how to connect to GOV.UK Verify
-              <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
-                <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
-              </svg>
-            </a>
+<main class="govuk-main-wrapper--auto-spacing" id="main" role="main">
+  <div class="masthead">
+    <div class="govuk-width-container">
+      <div class="hero">
+        <div class="hero__content govuk-grid-row">
+          <div class="govuk-grid-column-two-thirds">
+            <div class="hero__body">
+              <h1 class="hero__title govuk-heading-xl">
+                Be sure your users are who they say they are
+              </h1>
+              <p class="hero__description govuk-body">
+                GOV.UK Verify is a trusted, secure way to prove identity online. Designed to prevent identity fraud and protect users’ privacy, it’s a safe way to make sure you’re giving the right people access to your service.
+              </p>
+              <a href="/connecting" role="button" draggable="false" class="hero-button govuk-button govuk-button--start" data-module="govuk-button" data-click-events data-click-category="Hero" data-click-action="Button clicked">
+                Find out how to connect to GOV.UK Verify
+                <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
+                  <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+                </svg>
+              </a>
+            </div>
           </div>
-        </div>
-        <div class="govuk-grid-column-one-third">
-          <div class="hero__aside-image">
-            <img src="images/verify-product-image.svg" alt="" role="presentation">
+          <div class="govuk-grid-column-one-third">
+            <div class="hero__aside-image">
+              <img src="images/verify-product-image.svg" alt="" role="presentation">
+            </div>
           </div>
         </div>
       </div>
     </div>
   </div>
-</div>
 
-<main class="govuk-main-wrapper" id="main" role="main">
   <div class="govuk-width-container">
     <div class="govuk-grid-row content-section">
       <div class="govuk-grid-column-two-thirds">

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -113,7 +113,7 @@
               </li>
               <li class="govuk-footer__list-item">
                 <a class="govuk-footer__link" href="/sitemap">
-                  Sitemap
+                  Site map
                 </a>
               </li>
             </ul>

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -111,6 +111,11 @@
                   Performance
                 </a>
               </li>
+              <li class="govuk-footer__list-item">
+                <a class="govuk-footer__link" href="/sitemap">
+                  Sitemap
+                </a>
+              </li>
             </ul>
           </div>
         </div>

--- a/source/risk-assessment.html.erb
+++ b/source/risk-assessment.html.erb
@@ -3,7 +3,7 @@ title: Assess the risk of identity fraud to your service
 ---
 
 <div class="govuk-width-container">
-  <div class="govuk-breadcrumbs">
+  <nav aria-label="Breadcrumb" class="govuk-breadcrumbs">
     <ol class="govuk-breadcrumbs__list">
       <li class="govuk-breadcrumbs__list-item">
         <a class="govuk-breadcrumbs__link" href="https://www.gov.uk/service-toolkit#components">Components</a>
@@ -18,7 +18,7 @@ title: Assess the risk of identity fraud to your service
         <a href="#main">Assess the risk of identity fraud to your service</a>
       </li>
     </ol>
-  </div>
+  </nav>
 </div>
 
 <main class="govuk-main-wrapper" id="main" role="main">

--- a/source/sitemap.html.erb
+++ b/source/sitemap.html.erb
@@ -1,0 +1,70 @@
+---
+title: Sitemap – GOV.UK Verify
+---
+
+<div class="govuk-width-container">
+  <div class="govuk-breadcrumbs">
+    <ol class="govuk-breadcrumbs__list">
+      <li class="govuk-breadcrumbs__list-item">
+        <a class="govuk-breadcrumbs__link" href="https://www.gov.uk/service-toolkit#components">Components</a>
+      </li>
+      <li class="govuk-breadcrumbs__list-item">
+        <a class="govuk-breadcrumbs__link" href="/">GOV.UK Verify</a>
+      </li>
+      <li class="govuk-breadcrumbs__list-item" aria-current="page">
+        <a href="#main">Sitemap</a>
+      </li>
+    </ol>
+  </div>
+</div>
+
+<main class="govuk-main-wrapper" id="main" role="main">
+  <div class="govuk-width-container">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl">
+          Sitemap
+        </h1>
+        <h2 class="govuk-heading-s">
+          <a class="govuk-link" href="/">GOV.UK Verify Home</a>
+        </h2>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>
+            <a class="govuk-link" href="/connecting">Connecting to Verify</a>
+            <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-1">
+              <li>
+                <a class="govuk-link" href="/how-verify-works">How GOV.UK Verify works</a>
+              </li>
+              <li>
+                <a class="govuk-link" href="/verify-right-for-your-service">Find out if GOV.UK Verify is right for your service</a>
+              </li>
+              <li>
+                <a class="govuk-link" href="/understand-levels-of-assurance">Different levels of assurance (LOA)</a>
+              </li>
+              <li>
+                <a class="govuk-link" href="/risk-assessment">Risk assessment</a>
+              </li>
+              <li>
+                <a class="govuk-link" href="/design-your-service">User journey</a>
+                <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-1">
+                  <li>
+                    <a class="govuk-link" href="/user-journey-loa1">LOA1 service</a>
+                  </li>
+                  <li>
+                    <a class="govuk-link" href="/user-journey-loa2">LOA2 service</a>
+                  </li>
+                </ul>
+              </li>
+              <li>
+                <a class="govuk-link" href="/do-research-prototype">Do user research</a>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <a class="govuk-link" href="/support">Support</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</main>

--- a/source/sitemap.html.erb
+++ b/source/sitemap.html.erb
@@ -3,7 +3,7 @@ title: Sitemap – GOV.UK Verify
 ---
 
 <div class="govuk-width-container">
-  <div class="govuk-breadcrumbs">
+  <nav aria-label="Breadcrumb" class="govuk-breadcrumbs">
     <ol class="govuk-breadcrumbs__list">
       <li class="govuk-breadcrumbs__list-item">
         <a class="govuk-breadcrumbs__link" href="https://www.gov.uk/service-toolkit#components">Components</a>
@@ -15,7 +15,7 @@ title: Sitemap – GOV.UK Verify
         <a href="#main">Sitemap</a>
       </li>
     </ol>
-  </div>
+  </nav>
 </div>
 
 <main class="govuk-main-wrapper" id="main" role="main">

--- a/source/sitemap.html.erb
+++ b/source/sitemap.html.erb
@@ -1,5 +1,5 @@
 ---
-title: Sitemap – GOV.UK Verify
+title: Site map – GOV.UK Verify
 ---
 
 <div class="govuk-width-container">
@@ -12,7 +12,7 @@ title: Sitemap – GOV.UK Verify
         <a class="govuk-breadcrumbs__link" href="/">GOV.UK Verify</a>
       </li>
       <li class="govuk-breadcrumbs__list-item" aria-current="page">
-        <a href="#main">Sitemap</a>
+        <a href="#main">Site map</a>
       </li>
     </ol>
   </nav>
@@ -23,7 +23,7 @@ title: Sitemap – GOV.UK Verify
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-xl">
-          Sitemap
+          Site map
         </h1>
         <h2 class="govuk-heading-s">
           <a class="govuk-link" href="/">GOV.UK Verify Home</a>

--- a/source/stylesheets/modules/_masthead.scss
+++ b/source/stylesheets/modules/_masthead.scss
@@ -11,5 +11,8 @@
 
 .masthead {
   background-color: govuk-colour("blue");
-  margin-top: -25px;
+  margin-top: -10px;
+  &--breadcrumb {
+    margin-top: -25px;
+  }
 }

--- a/source/support.html.erb
+++ b/source/support.html.erb
@@ -3,7 +3,7 @@ title: Support – GOV.UK Verify
 ---
 
 <div class="govuk-width-container">
-  <div class="govuk-breadcrumbs">
+  <nav aria-label="Breadcrumb" class="govuk-breadcrumbs">
     <ol class="govuk-breadcrumbs__list">
       <li class="govuk-breadcrumbs__list-item">
         <a class="govuk-breadcrumbs__link" href="https://www.gov.uk/service-toolkit#components">Components</a>
@@ -15,7 +15,7 @@ title: Support – GOV.UK Verify
         <a href="#main">Support</a>
       </li>
     </ol>
-  </div>
+  </nav>
 </div>
 
 <main class="govuk-main-wrapper" id="main" role="main">

--- a/source/understand-levels-of-assurance.html.erb
+++ b/source/understand-levels-of-assurance.html.erb
@@ -3,7 +3,7 @@ title: Understand the different levels of assurance
 ---
 
 <div class="govuk-width-container">
-  <div class="govuk-breadcrumbs">
+  <nav aria-label="Breadcrumb" class="govuk-breadcrumbs">
     <ol class="govuk-breadcrumbs__list">
       <li class="govuk-breadcrumbs__list-item">
         <a class="govuk-breadcrumbs__link" href="https://www.gov.uk/service-toolkit#components">Components</a>
@@ -18,7 +18,7 @@ title: Understand the different levels of assurance
         <a href="#main">Understand the different levels of assurance</a>
       </li>
     </ol>
-  </div>
+  </nav>
 </div>
 
 <main class="govuk-main-wrapper" id="main" role="main">

--- a/source/user-journey-loa1.html.erb
+++ b/source/user-journey-loa1.html.erb
@@ -3,7 +3,7 @@ title: How the LOA1 user journey works
 ---
 
 <div class="govuk-width-container">
-  <div class="govuk-breadcrumbs">
+  <nav aria-label="Breadcrumb" class="govuk-breadcrumbs">
     <ol class="govuk-breadcrumbs__list">
       <li class="govuk-breadcrumbs__list-item">
         <a class="govuk-breadcrumbs__link" href="https://www.gov.uk/service-toolkit#components">Components</a>
@@ -21,7 +21,7 @@ title: How the LOA1 user journey works
         <a href="#main">How the LOA1 user journey works</a>
       </li>
     </ol>
-  </div>
+  </nav>
 </div>
 
 <main class="govuk-main-wrapper" id="main" role="main">

--- a/source/user-journey-loa2.html.erb
+++ b/source/user-journey-loa2.html.erb
@@ -3,7 +3,7 @@ title: How the LOA2 user journey works
 ---
 
 <div class="govuk-width-container">
-  <div class="govuk-breadcrumbs">
+  <nav aria-label="Breadcrumb" class="govuk-breadcrumbs">
     <ol class="govuk-breadcrumbs__list">
       <li class="govuk-breadcrumbs__list-item">
         <a class="govuk-breadcrumbs__link" href="https://www.gov.uk/service-toolkit#components">Components</a>
@@ -21,7 +21,7 @@ title: How the LOA2 user journey works
         <a href="#main">How the LOA2 user journey works</a>
       </li>
     </ol>
-  </div>
+  </nav>
 </div>
 
 <main class="govuk-main-wrapper" id="main" role="main">

--- a/source/verify-right-for-your-service.html.erb
+++ b/source/verify-right-for-your-service.html.erb
@@ -3,7 +3,7 @@ title: Find out if GOV.UK Verify is right for your service
 ---
 
 <div class="govuk-width-container">
-  <div class="govuk-breadcrumbs">
+  <nav aria-label="Breadcrumb" class="govuk-breadcrumbs">
     <ol class="govuk-breadcrumbs__list">
       <li class="govuk-breadcrumbs__list-item">
         <a class="govuk-breadcrumbs__link" href="https://www.gov.uk/service-toolkit#components">Components</a>
@@ -18,7 +18,7 @@ title: Find out if GOV.UK Verify is right for your service
         <a href="#main">Find out if GOV.UK Verify is right for your service</a>
       </li>
     </ol>
-  </div>
+  </nav>
 </div>
 
 <main class="govuk-main-wrapper" id="main" role="main">


### PR DESCRIPTION
Audit:
- ran through the WCAG 2.1 checklist to test the compliance
- tested with axe and PowerMapper
- manually tested with VoiceOver

Remediations:
- removed the `alt` attribute from a presentation image
- added sitemap
- move the breadcrumb to a correct landmark
- added missing `govuk-link` class on one of the links