### PR TITLE
Discourage end users from using our support email address

### DIFF
--- a/source/support.html.erb
+++ b/source/support.html.erb
@@ -25,41 +25,45 @@ title: Support – GOV.UK Verify
         <h1 class="govuk-heading-xl">
           Support
         </h1>
-        <h2 class="govuk-heading-l">
-          Support for service teams
-        </h2>
-        <p class="govuk-body">
-          GOV.UK Verify is supported 24 hours a day, 7 days a week by a full-time team at the Government Digital Service.
-        </p>
-        <p class="govuk-body">
-          <a href="https://verifystatus.digital.cabinet-office.gov.uk/" class="govuk-link">Check if any incidents have been reported</a> before you contact the GOV.UK Verify support team. You can sign up to get emails or text messages to find out when incidents are reported or updated.
-        </p>
-        <h3 class="govuk-heading-m">
-          Contacting GOV.UK Verify support
-        </h3>
-        <p class="govuk-body">
-          Email <a href="mailto:idasupport@digital.cabinet-office.gov.uk" class="govuk-link">idasupport@digital.cabinet-office.gov.uk</a> to get help and give feedback. We’ll usually reply by the next working day.
-        </p>
-        <p class="govuk-body">
-          If it’s an emergency, we’ll reply within 20 minutes and send you updates every hour until the problem is fixed.
-        </p>
-        <p class="govuk-body">
-          It’s an emergency if:
-        </p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>
-            a significant number of users cannot verify themselves to use your service
-          </li>
-          <li>
-            you think there’s been a security breach
-          </li>
-        </ul>
-        <h2 class="govuk-heading-l">
-          Get help signing in
-        </h2>
-        <p class="govuk-body">
-          If you need help signing in to your account, <a href="https://www.gov.uk/government/publications/introducing-govuk-verify/introducing-govuk-verify#how-to-get-help-signing-in" class="govuk-link">contact the identity provider (also called ‘certified company’) you set up your account with</a>.
-        </p>
+        <div>
+          <h2 class="govuk-heading-l">
+            Get help signing in
+          </h2>
+          <p class="govuk-body">
+            <a href="https://www.signin.service.gov.uk/feedback-landing?feedback-source=PRODUCT_PAGE">Find out who to contact</a> if you need help signing in to your account, or if you have feedback about GOV.UK Verify.
+          </p>
+        </div>
+        <div>
+          <h2 class="govuk-heading-l">
+            Support for service teams
+          </h2>
+          <p class="govuk-body">
+            GOV.UK Verify is supported 24 hours a day, 7 days a week by a full-time team at the Government Digital Service.
+          </p>
+          <p class="govuk-body">
+            <a href="https://verifystatus.digital.cabinet-office.gov.uk/" class="govuk-link">Check if any incidents have been reported</a> before you contact the GOV.UK Verify support team. You can sign up to get emails or text messages to find out when incidents are reported or updated.
+          </p>
+          <h3 class="govuk-heading-m">
+            Contacting GOV.UK Verify support
+          </h3>
+          <p class="govuk-body">
+            Email <a href="mailto:idasupport@digital.cabinet-office.gov.uk" class="govuk-link">idasupport@digital.cabinet-office.gov.uk</a> to get help and give feedback. We’ll usually reply by the next working day.
+          </p>
+          <p class="govuk-body">
+            If it’s an emergency, we’ll reply within 20 minutes and send you updates every hour until the problem is fixed.
+          </p>
+          <p class="govuk-body">
+            It’s an emergency if:
+          </p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>
+              a significant number of users cannot verify themselves to use your service
+            </li>
+            <li>
+              you think there’s been a security breach
+            </li>
+          </ul>
+        </div>
       </div>
     </div>
   </div>

--- a/source/support.html.erb
+++ b/source/support.html.erb
@@ -30,7 +30,7 @@ title: Support – GOV.UK Verify
             Get help signing in
           </h2>
           <p class="govuk-body">
-            <a href="https://www.signin.service.gov.uk/feedback-landing?feedback-source=PRODUCT_PAGE">Find out who to contact</a> if you need help signing in to your account, or if you have feedback about GOV.UK Verify.
+            <a href="https://www.signin.service.gov.uk/feedback-landing?feedback-source=PRODUCT_PAGE" class="govuk-link">Find out who to contact</a> if you need help signing in to your account, or if you have feedback about GOV.UK Verify.
           </p>
         </div>
         <div>


### PR DESCRIPTION
Adjust content to discourage end users from using our support email address

 - end users should get support from IDPs (or may wish to send feedback)
 - move instructions for end users above instructions for service teams to help achieve this
 - send them to a page which also gives a clear way for them to send feedback.

Before:
<img width="702" alt="Screen Shot 2019-10-10 at 17 01 02" src="https://user-images.githubusercontent.com/190828/66588586-b7995300-eb84-11e9-92cb-af5c2e8db0f4.png">

After:
<img width="623" alt="Screen Shot 2019-10-10 at 17 45 23" src="https://user-images.githubusercontent.com/190828/66589150-cf250b80-eb85-11e9-8c75-93d1bf5ff726.png">

