### PR TITLE
Add accessibility non-compliances

### DIFF
--- a/source/accessibility.html.erb
+++ b/source/accessibility.html.erb
@@ -55,7 +55,7 @@ title: Accessibility – GOV.UK Verify
           How accessible this website is
         </h2>
         <p class="govuk-body">
-          We are not aware of any current accessibility issues with this website.
+          We know some parts of this website are not fully accessible. There are parts of this website that are not accessible because of issues caused by the Verify status page.
         </p>
         <h2 class="govuk-heading-l">
           What to do if you cannot access parts of this website
@@ -84,14 +84,58 @@ title: Accessibility – GOV.UK Verify
         <p class="govuk-body">
           GDS is committed to making its website accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
         </p>
+        <h2 class="govuk-heading-l">
+          Compliance status
+        </h2>
         <p class="govuk-body">
-          This website is fully compliant with the <a href="https://www.w3.org/TR/WCAG21/" class="govuk-link">Web Content Accessibility Guidelines version 2.1</a> AA standard.
+          This website is partially compliant with the <a href="https://www.w3.org/TR/WCAG21/" class="govuk-link">Web Content Accessibility Guidelines version 2.1</a> AA standard, due to the non-compliances listed below.
+        </p>
+        <h3 class="govuk-heading-l">
+          Non-accessible content
+        </h3>
+        <p class="govuk-body">
+        The content listed below is non-accessible for the following reasons.
+        </p>
+        <h4 class="govuk-heading-l">
+          Non-compliance with the accessibility regulations
+        </h4>
+        <p class="govuk-body">
+          The following content on Verify Status Page is not compliant with the Web Content Accessibility Guidelines version 2.1 AA standard. The non-compliances are listed below:
+        <ul class="govuk-list govuk-list--bullet">
+          <li>
+            an incorrect heading hierarchy which fails WCAG 2.1A 1.3.1 success criterion (Info and Relationships)
+          </li>
+          <li>
+            missing level 1 headings (users may not be able to accurately determine the structure of content on the page)
+          </li>
+          <li>
+            our status incident page is missing the main heading and the status home page has an incorrect heading hierarchy. This fails WCAG 2.1A 1.3.1 success criterion (Info and Relationships).
+          </li>
+          <li>
+            our status page ‘subscribe to updates’ link does not contain programmatically discernible link text. This fails WCAG 2.1A 1.3.1 success criterion (Info and Relationships).
+          </li>
+          <li>
+            our status page subscribe to updates form fields do not contain an explicit label. This fails WCAG 2.1A 1.3.1 success criterion (Info and Relationships).
+          </li>
+          <li>
+            our status page subscribe to updates forms do not indicate to users that they are expandable or collapsible. This fails WCAG 2.1A 4.1.2 success criterion (Name, Role, Value).
+          </li>
+          <li>
+            our status page subscribe to updates forms contain some text that does not meet the minimum colour contrast requirements. This fails WCAG 2.1AA 1.4.3 success criterion (Contrast (Minimum)).
+          </li>
+          <li>
+            our status page subscribe to updates form close link (x) is not descriptive enough for some users to determine its function or purpose. This fails WCAG 2.1A 2.4.4 success criterion (Link Purpose (In Context)).
+          </li>
+          <li>
+            our status page subscribe to updates forms, when submitted with incorrect data, do not inform screen reader users of the error message when it becomes available. This fails WCAG 2.1AA 4.1.3 success criterion (Status Messages).
+          </li>
+          </ul>
         </p>
         <h2 class="govuk-heading-l">
           How we tested this website
         </h2>
         <p class="govuk-body">
-          We last tested this website for accessibility issues in September 2019.
+          We last tested this website for accessibility issues in September 2020.
         </p>
         <p class="govuk-body">
           We used manual and automated tests to look for issues such as:
@@ -116,7 +160,7 @@ title: Accessibility – GOV.UK Verify
             problems when using assistive technologies such as screen readers and screen magnifiers
           </li>
         </ul>
-        <p class="govuk-body">This statement was prepared on 20 September 2019. It was last updated on 20 September 2019.</p>
+        <p class="govuk-body">This statement was prepared on 20 September 2019. It was last updated on 24 September 2020.</p>
       </div>
     </div>
   </div>

--- a/source/accessibility.html.erb
+++ b/source/accessibility.html.erb
@@ -55,7 +55,7 @@ title: Accessibility – GOV.UK Verify
           How accessible this website is
         </h2>
         <p class="govuk-body">
-          We know some parts of this website are not fully accessible. There are parts of this website that are not accessible because of issues caused by the Verify status page.
+          We know some parts of this website are not fully accessible. There are parts of this website that are not accessible because of issues caused by the GOV.UK Verify status page.
         </p>
         <h2 class="govuk-heading-l">
           What to do if you cannot access parts of this website
@@ -100,7 +100,7 @@ title: Accessibility – GOV.UK Verify
           Non-compliance with the accessibility regulations
         </h4>
         <p class="govuk-body">
-          The following content on Verify Status Page is not compliant with the Web Content Accessibility Guidelines version 2.1 AA standard. The non-compliances are listed below:
+          The following content on GOV.UK Verify status page is not compliant with the Web Content Accessibility Guidelines version 2.1 AA standard. The non-compliances are listed below:
         <ul class="govuk-list govuk-list--bullet">
           <li>
             an incorrect heading hierarchy which fails WCAG 2.1A 1.3.1 success criterion (Info and Relationships)
@@ -109,25 +109,25 @@ title: Accessibility – GOV.UK Verify
             missing level 1 headings (users may not be able to accurately determine the structure of content on the page)
           </li>
           <li>
-            our status incident page is missing the main heading and the status home page has an incorrect heading hierarchy. This fails WCAG 2.1A 1.3.1 success criterion (Info and Relationships).
+            our status incident page is missing the main heading and the status home page has an incorrect heading hierarchy - this fails WCAG 2.1A 1.3.1 success criterion (Info and Relationships)
           </li>
           <li>
-            our status page ‘subscribe to updates’ link does not contain programmatically discernible link text. This fails WCAG 2.1A 1.3.1 success criterion (Info and Relationships).
+            our status page ‘subscribe to updates’ link does not contain programmatically discernible link text - this fails WCAG 2.1A 1.3.1 success criterion (Info and Relationships)
           </li>
           <li>
-            our status page subscribe to updates form fields do not contain an explicit label. This fails WCAG 2.1A 1.3.1 success criterion (Info and Relationships).
+            our status page subscribe to updates form fields do not contain an explicit label - this fails WCAG 2.1A 1.3.1 success criterion (Info and Relationships)
           </li>
           <li>
-            our status page subscribe to updates forms do not indicate to users that they are expandable or collapsible. This fails WCAG 2.1A 4.1.2 success criterion (Name, Role, Value).
+            our status page subscribe to updates forms do not indicate to users that they are expandable or collapsible - this fails WCAG 2.1A 4.1.2 success criterion (Name, Role, Value)
           </li>
           <li>
-            our status page subscribe to updates forms contain some text that does not meet the minimum colour contrast requirements. This fails WCAG 2.1AA 1.4.3 success criterion (Contrast (Minimum)).
+            our status page subscribe to updates forms contain some text that does not meet the minimum colour contrast requirements - this fails WCAG 2.1AA 1.4.3 success criterion (Contrast (Minimum))
           </li>
           <li>
-            our status page subscribe to updates form close link (x) is not descriptive enough for some users to determine its function or purpose. This fails WCAG 2.1A 2.4.4 success criterion (Link Purpose (In Context)).
+            our status page subscribe to updates form close link (x) is not descriptive enough for some users to determine its function or purpose - this fails WCAG 2.1A 2.4.4 success criterion (Link Purpose (In Context))
           </li>
           <li>
-            our status page subscribe to updates forms, when submitted with incorrect data, do not inform screen reader users of the error message when it becomes available. This fails WCAG 2.1AA 4.1.3 success criterion (Status Messages).
+            our status page subscribe to updates forms, when submitted with incorrect data, do not inform screen reader users of the error message when it becomes available - this fails WCAG 2.1AA 4.1.3 success criterion (Status Messages)
           </li>
           </ul>
         </p>


### PR DESCRIPTION
Update the non-compliances in the accessibility statement to include issues caused by the status page and sections where we previously stated no known issues. 