### PR TITLE
BAU remove video from Verify product page

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -100,9 +100,6 @@ title: GOV.UK Verify
           <p class="govuk-body">
             Read more about <a href="/how-verify-works" class="govuk-link">how GOV.UK Verify works</a>.
           </p>
-          <div class="content-section__video">
-            <iframe title="Video: How GOV.UK Verify works" width="560" height="315" src="https://www.youtube.com/embed/zmTpFl5DVSY" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
The video that used to feature on the Verify product page is out of date and unrepresentative.

It was made private some time ago, but the product page was not updated to remove it.

This PR removes the video embed on the product page.