### PR TITLE
HUB-875: Remove disconnecting IDPs

### DIFF
--- a/source/how-verify-works.html.erb
+++ b/source/how-verify-works.html.erb
@@ -35,11 +35,8 @@ title: How GOV.UK Verify works
           The identity providers have met government and industry standards to provide identity assurance services as part of GOV.UK Verify. They work with GOV.UK Verify to ensure users’ data is handled securely, helping your service to meet its data protection obligations.
         </p>
         <p class="govuk-body">
-          The identity providers that currently work with GOV.UK Verify are Barclays, Digidentity, Experian, Post Office and SecureIdentity.
+          The identity providers that currently work with GOV.UK Verify are Digidentity and Post Office.
         </p>
-        <div class="govuk-inset-text">
-        From 23 March 2020, users can create new identity accounts with Digidentity and Post Office only. They can still sign into government services using existing Barclays, Experian and SecureIdentity accounts until 24 March 2021.
-        </div>
         <h2 class="govuk-heading-l">
           How users are verified during the signup journey
         </h2>


### PR DESCRIPTION
We're losing the IDPs on March 23 2021. This should only be merged once
they've been removed.